### PR TITLE
Example of deploying CLIPTextModel to OpenSearch

### DIFF
--- a/docs/source/examples/demo_deploy_cliptextmodel.ipynb
+++ b/docs/source/examples/demo_deploy_cliptextmodel.ipynb
@@ -1,0 +1,343 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Demo Notebook for deploying CLIPTextModel to OpenSearch\n",
+    "\n",
+    "#### [Download notebook](placeholder_for_url)\n",
+    "\n",
+    "Related Docs:\n",
+    "* [OpenSearch ML Framework](https://opensearch.org/docs/latest/ml-commons-plugin/ml-framework/)\n",
+    "* [Huggingface - CLIP](https://huggingface.co/docs/transformers/model_doc/clip)\n",
+    "* [Huggingface - export to torchscript](https://huggingface.co/docs/transformers/torchscript)\n",
+    "\n",
+    "This notebook provides a walkthrough for users to trace, register, and deploy a CLIPTextModel from a local file. CLIPTextModel can be used with the [Neural Search](https://opensearch.org/docs/latest/search-plugins/neural-search/) plugin to generate embeddings of documents and ingest time and of user queries at search time. \n",
+    "\n",
+    "Step 0: Import packages and set up client\n",
+    "\n",
+    "Step 1: Trace CLIPTextModel and export to TorchScript\n",
+    "\n",
+    "Step 2: Prep files for registration\n",
+    "\n",
+    "Step 3: Register model to OpenSearch\n",
+    "\n",
+    "Step 4: Deploy model"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 0: Import packages and set up client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 52,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from transformers import CLIPProcessor, CLIPTextModel\n",
+    "import torch\n",
+    "\n",
+    "import opensearch_py_ml as oml\n",
+    "from opensearch_py_ml.ml_commons import MLCommonClient\n",
+    "from opensearchpy import OpenSearch\n",
+    "\n",
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\", message=\"Unverified HTTPS request\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Connect to OpenSearch cluster\n",
+    "host = 'localhost'\n",
+    "port = 9200\n",
+    "auth = ('admin', 'admin') # For testing only. Don't store credentials in code.\n",
+    "\n",
+    "def get_os_client(cluster_url = CLUSTER_URL,username='admin',password='admin'):\n",
+    "    '''\n",
+    "    Get OpenSearch client\n",
+    "    :param cluster_url: cluster URL like https://ml-te-netwo-1s12ba42br23v-ff1736fa7db98ff2.elb.us-west-2.amazonaws.com:443\n",
+    "    :return: OpenSearch client\n",
+    "    '''\n",
+    "    client = OpenSearch(\n",
+    "        hosts = [{'host': host, 'port': port}],\n",
+    "        http_compress = True, # enables gzip compression for request bodies\n",
+    "        http_auth = auth,\n",
+    "        use_ssl = False,\n",
+    "        verify_certs = False,\n",
+    "        ssl_assert_hostname = False,\n",
+    "        ssl_show_warn = False,\n",
+    "    )\n",
+    "    return client"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 54,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client = get_os_client()\n",
+    "ml_client = MLCommonClient(client)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Trace CLIPTextModel and export to TorchScript\n",
+    "\n",
+    "To use a model in OpenSearch, you’ll need to export the model into a portable format. As of Version 2.5, OpenSearch only supports the TorchScript and ONNX formats.\n",
+    "\n",
+    "Exporting a model to TorchScript requires two things:\n",
+    "\n",
+    "* model instantiation with the torchscript flag\n",
+    "* a forward pass with dummy inputs\n",
+    "\n",
+    "The dummy inputs are used for a model's forward pass. While the inputs’ values are propagated through the layers, PyTorch keeps track of the different operations executed on each tensor. These recorded operations are then used to create the trace of the model.\n",
+    "\n",
+    "As of OpenSearch 2.6, the ML Framework supports text-embedding models only. CLIP is multi-modal, but we will use CLIPTextModel only here."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 55,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "c:\\Users\\patri\\anaconda3\\envs\\opensearch_ml\\lib\\site-packages\\transformers\\models\\clip\\modeling_clip.py:287: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if attn_weights.size() != (bsz * self.num_heads, tgt_len, src_len):\n",
+      "c:\\Users\\patri\\anaconda3\\envs\\opensearch_ml\\lib\\site-packages\\transformers\\models\\clip\\modeling_clip.py:295: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if causal_attention_mask.size() != (bsz, 1, tgt_len, src_len):\n",
+      "c:\\Users\\patri\\anaconda3\\envs\\opensearch_ml\\lib\\site-packages\\transformers\\models\\clip\\modeling_clip.py:304: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if attention_mask.size() != (bsz, 1, tgt_len, src_len):\n",
+      "c:\\Users\\patri\\anaconda3\\envs\\opensearch_ml\\lib\\site-packages\\transformers\\models\\clip\\modeling_clip.py:327: TracerWarning: Converting a tensor to a Python boolean might cause the trace to be incorrect. We can't record the data flow of Python values, so this value will be treated as a constant in the future. This means that the trace might not generalize to other inputs!\n",
+      "  if attn_output.size() != (bsz * self.num_heads, tgt_len, self.head_dim):\n"
+     ]
+    }
+   ],
+   "source": [
+    "model_name = \"openai/clip-vit-base-patch32\" #See https://huggingface.co/models for other options \n",
+    "text_to_encode = \"example search query\" #See https://huggingface.co/docs/transformers/torchscript for more info on dummy inputs\n",
+    "\n",
+    "# Instantiate CLIPTextModel and CLIPProcessor with pretrained weights\n",
+    "model = CLIPTextModel.from_pretrained(model_name, torchscript=True, return_dict=False)\n",
+    "processor = CLIPProcessor.from_pretrained(model_name)\n",
+    "\n",
+    "# Use processor to generate tensors and create dummy input\n",
+    "text_inputs =processor(text=text_to_encode, return_tensors=\"pt\",max_length=77, padding=\"max_length\", truncation=True)\n",
+    "dummy_input = [text_inputs['input_ids'], text_inputs['attention_mask']]\n",
+    "\n",
+    "# Trace model and convert to torchscript object\n",
+    "traced_model = torch.jit.trace(model, dummy_input)\n",
+    "\n",
+    "# Save model in portable format\n",
+    "torch.jit.save(traced_model, \"traced_model_example.pt\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Prep files for registration\n",
+    "\n",
+    "OpenSearch requires two files zipped together for registration:\n",
+    "* Model in TorchScript format\n",
+    "* tokenizor.json file\n",
+    "\n",
+    "The tokenizor for the model used in this example can be found [here](https://huggingface.co/openai/clip-vit-base-patch32/tree/main)\n",
+    "\n",
+    "Additionally, a config.json file with the following details must be passed with the .zip. More info on [model config](clip-vit-base-patch32) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 57,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'\\n{\\n    \"name\": \"clip-vit-base-patch32\",\\n    \"version\": \\'1.0.0\\',\\n    \"model_format\": \"TORCH_SCRIPT\",\\n    \"model_config\": {\\n        \"model_type\": \"clip\",\\n        \"embedding_dimension\": 512,\\n        \"framework_type\": \"huggingface_transformers\"\\n    }\\n}\\n'"
+      ]
+     },
+     "execution_count": 57,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# config.json sample contents\n",
+    "\"\"\"\n",
+    "{\n",
+    "    \"name\": \"clip-vit-base-patch32\",\n",
+    "    \"version\": '1.0.0',\n",
+    "    \"model_format\": \"TORCH_SCRIPT\",\n",
+    "    \"model_config\": {\n",
+    "        \"model_type\": \"clip\",\n",
+    "        \"embedding_dimension\": 512,\n",
+    "        \"framework_type\": \"huggingface_transformers\"\n",
+    "    }\n",
+    "}\n",
+    "\"\"\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Register model to OpenSearch\n",
+    "\n",
+    "* Model name in config.json should match .pt torchscript file name\n",
+    "* Record the model ID from the output of the next cell\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'ml_client' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[1;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[1;32mc:\\Users\\patri\\OneDrive\\Dahlia\\OpenSearch\\demo_deploy_cliptextmodel.ipynb Cell 11\u001b[0m line \u001b[0;36m4\n\u001b[0;32m      <a href='vscode-notebook-cell:/c%3A/Users/patri/OneDrive/Dahlia/OpenSearch/demo_deploy_cliptextmodel.ipynb#X13sZmlsZQ%3D%3D?line=0'>1</a>\u001b[0m model_path \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m/fashion_clip_TS_v3.zip\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[0;32m      <a href='vscode-notebook-cell:/c%3A/Users/patri/OneDrive/Dahlia/OpenSearch/demo_deploy_cliptextmodel.ipynb#X13sZmlsZQ%3D%3D?line=1'>2</a>\u001b[0m model_config_path \u001b[39m=\u001b[39m \u001b[39m\"\u001b[39m\u001b[39m/config.json\u001b[39m\u001b[39m\"\u001b[39m\n\u001b[1;32m----> <a href='vscode-notebook-cell:/c%3A/Users/patri/OneDrive/Dahlia/OpenSearch/demo_deploy_cliptextmodel.ipynb#X13sZmlsZQ%3D%3D?line=3'>4</a>\u001b[0m model_id_file_system \u001b[39m=\u001b[39m ml_client\u001b[39m.\u001b[39mregister_model(model_path, model_config_path, isVerbose\u001b[39m=\u001b[39m\u001b[39mTrue\u001b[39;00m, deploy_model \u001b[39m=\u001b[39m \u001b[39mFalse\u001b[39;00m)\n",
+      "\u001b[1;31mNameError\u001b[0m: name 'ml_client' is not defined"
+     ]
+    },
+    {
+     "ename": "",
+     "evalue": "",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[1;31mThe Kernel crashed while executing code in the the current cell or a previous cell. Please review the code in the cell(s) to identify a possible cause of the failure. Click <a href='https://aka.ms/vscodeJupyterKernelCrash'>here</a> for more info. View Jupyter <a href='command:jupyter.viewOutput'>log</a> for further details."
+     ]
+    }
+   ],
+   "source": [
+    "model_path = \"<your_path>/<your_zipped_folder>.zip\"\n",
+    "model_config_path = \"<your_path>/config.json\"\n",
+    "\n",
+    "model_id_file_system = ml_client.register_model(model_path, model_config_path, isVerbose=True, deploy_model = False)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Deploy model\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 60,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "task_id: JXKtkIoBlaNlvM5RgN8J\n",
+      "Model deployed successfully\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'model_id': 'JHKtkIoBlaNlvM5RHN8H',\n",
+       " 'task_type': 'DEPLOY_MODEL',\n",
+       " 'function_name': 'TEXT_EMBEDDING',\n",
+       " 'state': 'COMPLETED',\n",
+       " 'worker_node': ['4K6CeIPPTkKiwZMplvJ6CQ'],\n",
+       " 'create_time': 1694644404233,\n",
+       " 'last_update_time': 1694644410593,\n",
+       " 'is_async': True}"
+      ]
+     },
+     "execution_count": 60,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_id = 'JHtkIBlaN3lvMRH8H' #your model ID from previous step\n",
+    "ml_client.deploy_model(model_id)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 61,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'name': 'traced_model_example2',\n",
+       " 'model_group_id': 'I3KtkIoBlaNlvM5RG9_f',\n",
+       " 'algorithm': 'TEXT_EMBEDDING',\n",
+       " 'model_version': '1',\n",
+       " 'model_format': 'TORCH_SCRIPT',\n",
+       " 'model_state': 'DEPLOYED',\n",
+       " 'model_content_size_in_bytes': 186971303,\n",
+       " 'model_content_hash_value': 'd478498a68f19acbee873b07b533a43b5efbfc75af70a9e0c3a7564aa09ab389',\n",
+       " 'model_config': {'model_type': 'clip',\n",
+       "  'embedding_dimension': 512,\n",
+       "  'framework_type': 'HUGGINGFACE_TRANSFORMERS'},\n",
+       " 'created_time': 1694644378631,\n",
+       " 'last_updated_time': 1694644410593,\n",
+       " 'last_deployed_time': 1694644410593,\n",
+       " 'total_chunks': 19,\n",
+       " 'planning_worker_node_count': 1,\n",
+       " 'current_worker_node_count': 1,\n",
+       " 'planning_worker_nodes': ['4K6CeIPPTkKiwZMplvJ6CQ'],\n",
+       " 'deploy_to_all_nodes': True}"
+      ]
+     },
+     "execution_count": 61,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Check model status\n",
+    "ml_client.get_model_info(model_id)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "opensearch_ml",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.0"
+  },
+  "orig_nbformat": 4
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook provides a walkthrough for users to trace, register, and deploy a CLIPTextModel from a local file. CLIPTextModel can be used with the neural search plugin to generate embeddings of documents and ingest time and of user queries at search time.

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] New functionality includes testing.
  - [ ] All tests pass
- [ ] New functionality has been documented.
  - [ ] New functionality has javadoc added
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
